### PR TITLE
fix/molecules/LikedLoanProductDetailItem

### DIFF
--- a/life_on_hana/stories/LikedLoanProductDetailItem.stories.tsx
+++ b/life_on_hana/stories/LikedLoanProductDetailItem.stories.tsx
@@ -21,6 +21,13 @@ const meta: Meta<typeof LikedLoanProductDetailItem> = {
       defaultValue: true, 
     },
   },
+  decorators: [
+    (Story) => (
+      <div style={{ minHeight: "480px", padding: "20px", boxSizing: "border-box" }}>
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export default meta;


### PR DESCRIPTION
## 💻 작업 내용

수정하면서 LikedLoanProductDetailItem쪽에만
storybook의 docs쪽 높이수정부분이 빠져있어서 다시 pr 보냅니다!


Before
![image](https://github.com/user-attachments/assets/50068f6c-6702-4c39-b70d-4343af366f14)

After
![image](https://github.com/user-attachments/assets/faaf8452-ad0f-4e46-af97-2025431116e0)
