### PR TITLE
fix/molecules/SearchInput

### DIFF
--- a/life_on_hana/components/molecules/SearchInput.tsx
+++ b/life_on_hana/components/molecules/SearchInput.tsx
@@ -12,7 +12,7 @@ export default function SearchInput({ placeholder, value = "" }: TSearchInput) {
   };
 
   return (
-    <div className="relative flex items-center w-[22.6875rem] h-[2.125rem]">
+    <div className="relative flex items-center w-full h-[2.125rem]">
       <input
         type="text"
         value={inputValue}


### PR DESCRIPTION
## 💻 작업 내용

<img width="781" alt="image" src="https://github.com/user-attachments/assets/44a27169-d5e6-4286-9340-4011216f208c" />

가로길이를 w-full로 지정하여서 화면크기에 맞게 가로길이가 설정되도록 하였습니다!


## 💬 리뷰 요구사항(선택)
