### PR TITLE
feature/pages/Signin-Mydata

### DIFF
--- a/life_on_hana/app/(routes)/signin/mydata/page.tsx
+++ b/life_on_hana/app/(routes)/signin/mydata/page.tsx
@@ -1,7 +1,44 @@
+"use client";
+
+import MicroMiniBtn from "@/components/atoms/MicroMiniBtn";
+import ConnectBankItem from "@/components/molecules/ConnectBankItem";
+import Link from "next/link";
+
 export default function mydata() {
   return (
     <>
-      <>마이데이터 페이지입니다.</>
+      <div className="relative h-full ">
+        <div className="pt-[5rem] px-[1.5rem]">
+          <div className="font-SCDream3 text-[23px] mb-2">
+            <span className="font-Hana2heavy text-hanapurple">LIFE on HANA</span> 가입을 위해
+            <br />
+            마이데이터 서비스를 <span className="font-SCDream5">가입</span>합니다
+          </div>
+          <div className="font-SCDream3 text-[12px] text-hanadeepgray mb-20">
+            탈퇴 시 마이데이터로 연결된 모든 자산과 개인정보가 삭제(유효한 전송요구도 함께 중단)되며, 서비스 재이용을
+            위해서는 다시 전송동의가 필요해요.{" "}
+          </div>
+          <div className="flex items-center gap-3 font-SCDream5 text-[14px] mb-5">
+            연결되는 데이터
+            <MicroMiniBtn num={5} />
+          </div>
+          <div className="flex flex-col items-center">
+            <ConnectBankItem bankName="HANA" />
+            <ConnectBankItem bankName="NH" />
+            <ConnectBankItem bankName="SHINHAN" />
+            <ConnectBankItem bankName="WOORI" />
+            <ConnectBankItem bankName="TOSS" />
+            <ConnectBankItem bankName="NAVER" />
+            <ConnectBankItem bankName="KAKAO" />
+          </div>
+        </div>
+
+        <Link href="/home">
+          <button className="fixed w-full bottom-0 h-[100px] flex justify-center pt-5 font-SCDream3 text-[18px] bg-[#731BEC] text-white">
+            마이데이터 서비스 연결
+          </button>
+        </Link>
+      </div>
     </>
   );
 }

--- a/life_on_hana/app/(routes)/signin/mydata/page.tsx
+++ b/life_on_hana/app/(routes)/signin/mydata/page.tsx
@@ -2,13 +2,28 @@
 
 import MicroMiniBtn from "@/components/atoms/MicroMiniBtn";
 import ConnectBankItem from "@/components/molecules/ConnectBankItem";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 
-export default function mydata() {
+export default function Mydata() {
+  const router = useRouter();
+  const [clickedNum, setClickedNum] = useState(0);
+
+  const handleToggle = (isChecked: boolean) => {
+    setClickedNum((prev) => (isChecked ? prev + 1 : prev - 1));
+  };
+
+  const moveToHomeEvent = () => {
+    if (clickedNum !== 0) {
+      router.replace("/home");
+    }
+    return;
+  };
+
   return (
     <>
       <div className="relative h-full ">
-        <div className="pt-[5rem] px-[1.5rem]">
+        <div className="pt-[5rem] px-[1.5rem] mb-[120px]">
           <div className="font-SCDream3 text-[23px] mb-2">
             <span className="font-Hana2heavy text-hanapurple">LIFE on HANA</span> 가입을 위해
             <br />
@@ -20,24 +35,25 @@ export default function mydata() {
           </div>
           <div className="flex items-center gap-3 font-SCDream5 text-[14px] mb-5">
             연결되는 데이터
-            <MicroMiniBtn num={5} />
+            <MicroMiniBtn num={clickedNum} />
           </div>
-          <div className="flex flex-col items-center">
-            <ConnectBankItem bankName="HANA" />
-            <ConnectBankItem bankName="NH" />
-            <ConnectBankItem bankName="SHINHAN" />
-            <ConnectBankItem bankName="WOORI" />
-            <ConnectBankItem bankName="TOSS" />
-            <ConnectBankItem bankName="NAVER" />
-            <ConnectBankItem bankName="KAKAO" />
+          <div className="flex flex-col items-center gap-2">
+            <ConnectBankItem bankName="HANA" onToggle={handleToggle} />
+            <ConnectBankItem bankName="NH" onToggle={handleToggle} />
+            <ConnectBankItem bankName="SHINHAN" onToggle={handleToggle} />
+            <ConnectBankItem bankName="WOORI" onToggle={handleToggle} />
+            <ConnectBankItem bankName="TOSS" onToggle={handleToggle} />
+            <ConnectBankItem bankName="NAVER" onToggle={handleToggle} />
+            <ConnectBankItem bankName="KAKAO" onToggle={handleToggle} />
           </div>
         </div>
 
-        <Link href="/home">
-          <button className="fixed w-full bottom-0 h-[100px] flex justify-center pt-5 font-SCDream3 text-[18px] bg-[#731BEC] text-white">
-            마이데이터 서비스 연결
-          </button>
-        </Link>
+        <button
+          onClick={moveToHomeEvent}
+          className="rounded-t-xl fixed w-full bottom-0 h-[80px] flex justify-center pt-5 font-SCDream3 text-[15px] bg-hanapurple text-white"
+        >
+          마이데이터 서비스 연결
+        </button>
       </div>
     </>
   );

--- a/life_on_hana/app/(routes)/signin/mydata/page.tsx
+++ b/life_on_hana/app/(routes)/signin/mydata/page.tsx
@@ -4,6 +4,7 @@ import MicroMiniBtn from "@/components/atoms/MicroMiniBtn";
 import ConnectBankItem from "@/components/molecules/ConnectBankItem";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { twMerge } from "tailwind-merge";
 
 export default function Mydata() {
   const router = useRouter();
@@ -50,7 +51,10 @@ export default function Mydata() {
 
         <button
           onClick={moveToHomeEvent}
-          className="rounded-t-xl fixed w-full bottom-0 h-[6.5rem] flex justify-center pt-5 font-SCDream3 text-[1rem] bg-hanapurple text-white"
+          className={twMerge(
+            "rounded-t-xl fixed w-full bottom-0 h-[6.5rem] flex justify-center pt-5 font-SCDream3 text-[1rem] text-white",
+            clickedNum === 0 ? "bg-hanadeepgray " : "bg-hanapurple"
+          )}
         >
           마이데이터 서비스 연결
         </button>

--- a/life_on_hana/app/(routes)/signin/mydata/page.tsx
+++ b/life_on_hana/app/(routes)/signin/mydata/page.tsx
@@ -23,17 +23,17 @@ export default function Mydata() {
   return (
     <>
       <div className="relative h-full ">
-        <div className="pt-[5rem] px-[1.5rem] mb-[120px]">
-          <div className="font-SCDream3 text-[23px] mb-2">
+        <div className="pt-[5rem] px-[1.5rem] mb-[7.5rem]">
+          <div className="font-SCDream3 text-[1.6rem] mb-2">
             <span className="font-Hana2heavy text-hanapurple">LIFE on HANA</span> 가입을 위해
             <br />
             마이데이터 서비스를 <span className="font-SCDream5">가입</span>합니다
           </div>
-          <div className="font-SCDream3 text-[12px] text-hanadeepgray mb-20">
+          <div className="font-SCDream3 text-[.75rem] text-hanadeepgray mb-14">
             탈퇴 시 마이데이터로 연결된 모든 자산과 개인정보가 삭제(유효한 전송요구도 함께 중단)되며, 서비스 재이용을
             위해서는 다시 전송동의가 필요해요.{" "}
           </div>
-          <div className="flex items-center gap-3 font-SCDream5 text-[14px] mb-5">
+          <div className="flex items-center gap-3 font-SCDream5 text-[1.2rem] mb-5">
             연결되는 데이터
             <MicroMiniBtn num={clickedNum} />
           </div>
@@ -50,7 +50,7 @@ export default function Mydata() {
 
         <button
           onClick={moveToHomeEvent}
-          className="rounded-t-xl fixed w-full bottom-0 h-[80px] flex justify-center pt-5 font-SCDream3 text-[15px] bg-hanapurple text-white"
+          className="rounded-t-xl fixed w-full bottom-0 h-[6.5rem] flex justify-center pt-5 font-SCDream3 text-[1rem] bg-hanapurple text-white"
         >
           마이데이터 서비스 연결
         </button>

--- a/life_on_hana/app/layout.tsx
+++ b/life_on_hana/app/layout.tsx
@@ -5,7 +5,7 @@ import { DataProvider } from "@/hooks/useData";
 import { SessionProvider } from "next-auth/react";
 import { auth } from "@/lib/auth";
 import { Toaster } from "@/components/ui/toaster";
-import Nav from "@/components/molecules/Nav";
+// import Nav from "@/components/molecules/Nav";
 
 export const metadata: Metadata = {
   title: "LIFE on HANA",
@@ -29,7 +29,7 @@ export default async function RootLayout({
         <SessionProvider session={session}>
           <DataProvider getSession={getSession} signOut={signOut}>
             {children}
-            {session && <Nav />}
+            {/* {session && <Nav />} */}
           </DataProvider>
         </SessionProvider>
         <Toaster />

--- a/life_on_hana/components/molecules/ConnectBankItem.tsx
+++ b/life_on_hana/components/molecules/ConnectBankItem.tsx
@@ -42,8 +42,8 @@ export default function ConnectBankItem({ bankName, initialIsMydataChecked = fal
   const displayBankName = bankNameMap[bankName];
 
   return (
-    <div className="w-[24.5625rem] h-[3.75rem] flex items-center justify-between relative">
-      <div className="flex items-center ml-5">
+    <div className="w-full h-[3.75rem] flex items-center justify-between relative">
+      <div className="flex items-center">
         <Image className="w-5 h-[.95rem]" src={bankLogo} alt={`${bankName} Logo`} width={20} height={15} />
         <div className="ml-2 text-black text-[.9375rem] font-SCDream3">{displayBankName}</div>
       </div>

--- a/life_on_hana/components/molecules/ConnectBankItem.tsx
+++ b/life_on_hana/components/molecules/ConnectBankItem.tsx
@@ -9,13 +9,15 @@ import WooriBankLogo from "../../assets/WooriBankLogo.svg";
 import TossBankLogo from "../../assets/TossBankLogo.svg";
 import NaverBankLogo from "../../assets/NaverBankLogo.svg";
 import KakaoBankLogo from "../../assets/KakaoBankLogo.svg";
-import { TConnectBankItemProps } from "@/types/componentTypes";
+import { type TConnectBankItemProps } from "@/types/componentTypes";
 
-export default function ConnectBankItem({ bankName, initialIsMydataChecked = false }: TConnectBankItemProps) {
+export default function ConnectBankItem({ bankName, initialIsMydataChecked = false, onToggle }: TConnectBankItemProps) {
   const [isMydataChecked, setIsMydataChecked] = useState<boolean>(initialIsMydataChecked);
 
   const toggleMydata = () => {
-    setIsMydataChecked(!isMydataChecked);
+    const newCheckedState = !isMydataChecked;
+    setIsMydataChecked(newCheckedState);
+    onToggle(newCheckedState);
   };
 
   const bankLogoMap: Record<string, string> = {

--- a/life_on_hana/types/componentTypes.ts
+++ b/life_on_hana/types/componentTypes.ts
@@ -89,6 +89,7 @@ export type TColumnRecommendItemProps = {
 export type TConnectBankItemProps = {
   bankName: string;
   initialIsMydataChecked?: boolean;
+  onToggle: (isChecked: boolean) => void;
 };
 
 export type THistoryItemCategoryProps =


### PR DESCRIPTION
## #️⃣ 이슈 번호

> Resolve: #91

## 💻 작업 내용

<img width="781" alt="image" src="https://github.com/user-attachments/assets/74c2daad-7dc0-4ad6-83af-2652dc62bb66" />
<img width="781" alt="image" src="https://github.com/user-attachments/assets/e2d5957e-5c2d-4ca8-a0e7-c71104debf71" />

- [x] 선택한 은행 수 버튼 내에 반영
- [x] 은행 선택 하나도 안 할 경우 '마이데이터 서비스 연결' 버튼을 통한 '/home'으로 이동 제한
- [x] 은행 선택 여부에 따른 '마이데이터 서비스 연결' 버튼 색상 차별화

## 💬 리뷰 요구사항(선택)
