### PR TITLE
feature/refactor/NavHeader

### DIFF
--- a/life_on_hana/app/(routes)/column/[id]/page.tsx
+++ b/life_on_hana/app/(routes)/column/[id]/page.tsx
@@ -21,6 +21,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { fetchArticleById, likeArticle } from '@/api';
 import { DataContext } from '@/hooks/useData';
 import LoadingIcon from '@/components/atoms/LoadingIcon';
+import Link from 'next/link';
 
 const MOCK_DATA = {
   code: 200,
@@ -255,25 +256,28 @@ export default function Detail() {
           <MoveToBackBtn />
         </span>
       )}
-      <div className='flex flex-col items-center '>
-        <div
-          className={`w-[90%] flex items-center  ${
-            isLoading || !article ? 'mt-8' : '-mt-8'
-          }`}
-        >
-          <LogoHeader isMain={false} />
+
+      <Link href='/column'>
+        <div className='flex flex-col items-center'>
+          <div
+            className={`w-[90%] flex items-center  ${
+              isLoading || !article ? 'mt-8' : '-mt-8'
+            }`}
+          >
+            <LogoHeader isMain={false} />
+          </div>
+          <div className='w-[90%] flex items-center gap-3 mt-2 mb-4'>
+            <Image
+              src={column}
+              alt='column icon'
+              width={20}
+              height={20}
+              priority
+            />
+            <div className='text-[1.5rem] font-Hana2bold'>칼럼</div>
+          </div>
         </div>
-        <div className='w-[90%] flex items-center gap-3 mt-2 mb-4'>
-          <Image
-            src={column}
-            alt='column icon'
-            width={20}
-            height={20}
-            priority
-          />
-          <div className='text-[1.5rem] font-Hana2bold'>칼럼</div>
-        </div>
-      </div>
+      </Link>
 
       <div className='w-full flex flex-col'>
         <div className='w-full h-[80vh] overflow-y-auto'>

--- a/life_on_hana/app/(routes)/home/columns/page.tsx
+++ b/life_on_hana/app/(routes)/home/columns/page.tsx
@@ -80,9 +80,15 @@ export default function Columns() {
   );
 
   return (
-    <div className='p-6 w-screen py-6 space-y-4 mb-[3rem]'>
-      <NavHeader location={'좋아요한 칼럼'} beforePageUrl={'/home'} />
-      <div className='w-full h-full flex flex-col items-center justify-center mt-5'>
+    <div className='p-6 w-screen py-6 space-y-4 mb-28'>
+      <div className='fixed top-0 left-0 pt-6 px-6 w-full bg-background z-50'>
+        <NavHeader location={'좋아요한 칼럼'} beforePageUrl={'/home'} />
+      </div>
+
+      <div
+        className='w-full h-full flex flex-col items-center justify-center mt-5'
+        style={{ marginTop: '3.6rem' }}
+      >
         {likedArticles.length > 0 ? (
           <>
             {Array.from(

--- a/life_on_hana/app/(routes)/home/history/page.tsx
+++ b/life_on_hana/app/(routes)/home/history/page.tsx
@@ -188,9 +188,14 @@ export default function History() {
 
   return (
     <div className='p-6 space-y-8 mb-28'>
-      <NavHeader location={'이번달 입출금 내역'} beforePageUrl={'/home'} />
+      <div className='fixed top-0 left-0 pt-6 px-6 w-full bg-background z-50'>
+        <NavHeader location={'이번달 입출금 내역'} beforePageUrl={'/home'} />
+      </div>
 
-      <div className='w-full h-full flex flex-col items-center gap-4'>
+      <div
+        className='w-full h-full flex flex-col items-center gap-4'
+        style={{ marginTop: '4rem' }}
+      >
         <div className='w-full flex flex-row gap-x-4 justify-start items-center'>
           <div className='flex flex-row gap-x-4 font-SCDream5 text-[1.25rem]'>
             <Image src={monthLeft} alt={'monthLeft'} onClick={minusDate} />

--- a/life_on_hana/app/(routes)/home/like/page.tsx
+++ b/life_on_hana/app/(routes)/home/like/page.tsx
@@ -92,10 +92,14 @@ export default function Like() {
 
   return (
     <div className='flex flex-col h-screen'>
-      <div className='pt-6 px-6'>
+      <div className='fixed top-0 left-0 pt-6 px-6 w-full bg-background z-50'>
         <NavHeader location='좋아요한 상품' beforePageUrl='.' />
       </div>
-      <div className='flex-1 overflow-y-auto px-5 mb-32'>
+
+      <div
+        className='flex-1 overflow-y-auto px-5 mb-32'
+        style={{ marginTop: '5.5rem' }}
+      >
         <div className='flex flex-col gap-4 pb-[10vh]'>
           {products.map((product) => (
             <RecommendItem key={product.productId} {...product} />

--- a/life_on_hana/app/(routes)/home/lumpsum/page.tsx
+++ b/life_on_hana/app/(routes)/home/lumpsum/page.tsx
@@ -172,7 +172,9 @@ export default function Lumpsum() {
 
   return (
     <div className='p-6 space-y-8 mb-28'>
-      <NavHeader location={'목돈 가져오기'} beforePageUrl={'/home'} />
+      <div className='fixed top-0 left-0 pt-6 px-6 w-full bg-background z-50'>
+        <NavHeader location={'목돈 가져오기'} beforePageUrl={'/home'} />
+      </div>
 
       {selectedProduct?.type === 'LOAN' && (
         <LikedLoanProductDetailItem
@@ -181,102 +183,105 @@ export default function Lumpsum() {
           onClose={() => setSelectedProductProps(null)}
         />
       )}
-
-      <Section height='55rem'>
-        <div className='w-full'>
-          <div className='space-y-8'>
-            <div className='my-3 flex gap-2 font-SCDream3 text-[1.25rem] items-end'>
-              <input
-                type='text'
-                value={amount}
-                className='font-SCDream7 text-hanapurple border-b-2 border-hanapurple w-full text-[1.5625rem] text-right outline-none'
-                placeholder='금액을 입력해주세요'
-                onChange={handleChange}
-                onKeyDown={handleKeyDown}
-                autoFocus
-              />
-              을
-            </div>
-            <div className='flex gap-1 font-SCDream3 text-[1.25rem] items-end justify-between'>
-              <div className='flex justify-between gap-3'>
-                <LumpSumBtn
-                  variant={'hanaSalaryBank'}
-                  isSelected={selectedBtn === 'hanaSalaryBank'}
-                  onClick={() => handleBtnClick('hanaSalaryBank')}
+      <div style={{ marginTop: '4rem' }}>
+        <Section height='55rem'>
+          <div className='w-full'>
+            <div className='space-y-8'>
+              <div className='my-3 flex gap-2 font-SCDream3 text-[1.25rem] items-end'>
+                <input
+                  type='text'
+                  value={amount}
+                  className='font-SCDream7 text-hanapurple border-b-2 border-hanapurple w-full text-[1.5625rem] text-right outline-none'
+                  placeholder='금액을 입력해주세요'
+                  onChange={handleChange}
+                  onKeyDown={handleKeyDown}
+                  autoFocus
                 />
-                <LumpSumBtn
-                  variant={'otherAccounts'}
-                  isSelected={selectedBtn === 'otherAccounts'}
-                  onClick={() => handleBtnClick('otherAccounts')}
-                />
-                <LumpSumBtn
-                  variant={'loanProducts'}
-                  isSelected={selectedBtn === 'loanProducts'}
-                  onClick={() => handleBtnClick('loanProducts')}
-                />
+                을
               </div>
-              에서
-            </div>
-
-            <Section
-              height='300'
-              bgColor='hanalightpurple'
-              hasShadow
-              shadowColor='rgba(77,0,181,0.3)'
-            >
-              <div className='space-y-4'>
-                {reasons.map((item, index) => (
-                  <div
-                    key={index}
-                    className='space-y-4 flex flex-col cursor-pointer'
-                    onClick={() => setReason(item)}
-                  >
-                    <div className='space-x-3 flex items-center'>
-                      <input
-                        type='radio'
-                        id={`reason-${index}`}
-                        name='reason'
-                        value={item}
-                        checked={reason === item}
-                        onChange={() => handleReasonSelect(item)}
-                        className={`w-4 h-4 ${
-                          reason === item
-                            ? 'text-purple-500 border-purple-500'
-                            : ''
-                        }`}
-                      />
-                      <label
-                        htmlFor={`reason-${index}`}
-                        className={`font-SCDream3 text-[1.125rem] ${
-                          reason === item ? 'text-purple-500' : 'text-gray-800'
-                        }`}
-                      >
-                        {item}
-                      </label>
-                    </div>
-                    {index !== reasons.length - 1 && (
-                      <hr className='border border-gray-200 w-full' />
-                    )}
-                  </div>
-                ))}
-                {reason === '기타' && (
-                  <input
-                    type='text'
-                    placeholder='기타 선택 시, 필수 작성'
-                    value={customReason}
-                    maxLength={30}
-                    onChange={(e) => setCustomReason(e.target.value)}
-                    className='font-SCDream3 text-[1rem] w-full p-2 border border-hanalightpurple rounded-lg focus:border-hanapurple outline-none'
+              <div className='flex gap-1 font-SCDream3 text-[1.25rem] items-end justify-between'>
+                <div className='flex justify-between gap-3'>
+                  <LumpSumBtn
+                    variant={'hanaSalaryBank'}
+                    isSelected={selectedBtn === 'hanaSalaryBank'}
+                    onClick={() => handleBtnClick('hanaSalaryBank')}
                   />
-                )}
+                  <LumpSumBtn
+                    variant={'otherAccounts'}
+                    isSelected={selectedBtn === 'otherAccounts'}
+                    onClick={() => handleBtnClick('otherAccounts')}
+                  />
+                  <LumpSumBtn
+                    variant={'loanProducts'}
+                    isSelected={selectedBtn === 'loanProducts'}
+                    onClick={() => handleBtnClick('loanProducts')}
+                  />
+                </div>
+                에서
               </div>
-            </Section>
-            <div className='w-full flex justify-end font-SCDream3 text-[1.25rem]'>
-              의 이유로
+
+              <Section
+                height='300'
+                bgColor='hanalightpurple'
+                hasShadow
+                shadowColor='rgba(77,0,181,0.3)'
+              >
+                <div className='space-y-4'>
+                  {reasons.map((item, index) => (
+                    <div
+                      key={index}
+                      className='space-y-4 flex flex-col cursor-pointer'
+                      onClick={() => setReason(item)}
+                    >
+                      <div className='space-x-3 flex items-center'>
+                        <input
+                          type='radio'
+                          id={`reason-${index}`}
+                          name='reason'
+                          value={item}
+                          checked={reason === item}
+                          onChange={() => handleReasonSelect(item)}
+                          className={`w-4 h-4 ${
+                            reason === item
+                              ? 'text-purple-500 border-purple-500'
+                              : ''
+                          }`}
+                        />
+                        <label
+                          htmlFor={`reason-${index}`}
+                          className={`font-SCDream3 text-[1.125rem] ${
+                            reason === item
+                              ? 'text-purple-500'
+                              : 'text-gray-800'
+                          }`}
+                        >
+                          {item}
+                        </label>
+                      </div>
+                      {index !== reasons.length - 1 && (
+                        <hr className='border border-gray-200 w-full' />
+                      )}
+                    </div>
+                  ))}
+                  {reason === '기타' && (
+                    <input
+                      type='text'
+                      placeholder='기타 선택 시, 필수 작성'
+                      value={customReason}
+                      maxLength={30}
+                      onChange={(e) => setCustomReason(e.target.value)}
+                      className='font-SCDream3 text-[1rem] w-full p-2 border border-hanalightpurple rounded-lg focus:border-hanapurple outline-none'
+                    />
+                  )}
+                </div>
+              </Section>
+              <div className='w-full flex justify-end font-SCDream3 text-[1.25rem]'>
+                의 이유로
+              </div>
             </div>
           </div>
-        </div>
-      </Section>
+        </Section>
+      </div>
 
       <Btn
         text={`${

--- a/life_on_hana/app/(routes)/home/wallet/deposit/page.tsx
+++ b/life_on_hana/app/(routes)/home/wallet/deposit/page.tsx
@@ -95,9 +95,11 @@ export default function Deposit() {
   return (
     <div className='flex flex-col h-screen p-6'>
       <div className='sticky top-0 z-10'>
-        <NavHeader location={'하나 월급통장 채우기'} beforePageUrl={'.'} />
+        <div className='fixed top-0 left-0 pt-6 px-6 w-full bg-background z-50'>
+          <NavHeader location={'하나 월급통장 채우기'} beforePageUrl={'.'} />
+        </div>
 
-        <div className='mb-2 px-2'>
+        <div className='mb-2 px-2' style={{ marginTop: '4rem' }}>
           <div className='text-[1.25rem] font-SCDream5 mb-2'>입금계좌</div>
 
           {mainAccount && (

--- a/life_on_hana/app/(routes)/home/wallet/deposit/page.tsx
+++ b/life_on_hana/app/(routes)/home/wallet/deposit/page.tsx
@@ -96,7 +96,7 @@ export default function Deposit() {
     <div className='flex flex-col h-screen px-3'>
       <div className='sticky top-0 z-10'>
         <div className='pt-6'>
-          <NavHeader location={'하나 월급통장 채우기'} beforePageUrl={'..'} />
+          <NavHeader location={'하나 월급통장 채우기'} beforePageUrl={'.'} />
         </div>
 
         <div className='mb-2 px-2'>
@@ -124,7 +124,7 @@ export default function Deposit() {
                   </div>
                 </div>
               </div>
-              <div className='text-right font-SCDream8 text-[1rem] mr-4 mb-2'>
+              <div className='text-right font-SCDream8 text-[1.25rem] mr-4 mb-2'>
                 {mainAccount.balance.toLocaleString()} 원
               </div>
             </div>

--- a/life_on_hana/app/(routes)/home/wallet/deposit/page.tsx
+++ b/life_on_hana/app/(routes)/home/wallet/deposit/page.tsx
@@ -93,11 +93,9 @@ export default function Deposit() {
       : 'beforeChooseAccount';
 
   return (
-    <div className='flex flex-col h-screen px-3'>
+    <div className='flex flex-col h-screen p-6'>
       <div className='sticky top-0 z-10'>
-        <div className='pt-6'>
-          <NavHeader location={'하나 월급통장 채우기'} beforePageUrl={'.'} />
-        </div>
+        <NavHeader location={'하나 월급통장 채우기'} beforePageUrl={'.'} />
 
         <div className='mb-2 px-2'>
           <div className='text-[1.25rem] font-SCDream5 mb-2'>입금계좌</div>

--- a/life_on_hana/app/(routes)/home/wallet/page.tsx
+++ b/life_on_hana/app/(routes)/home/wallet/page.tsx
@@ -288,76 +288,81 @@ export default function Wallet() {
   };
 
   return (
-    <div className='p-6 space-y-8 mb-28'>
-      <NavHeader location={'하나 지갑 관리하기'} beforePageUrl={'/home'} />
-      <Section>
-        <div className='w-full space-y-3'>
-          <div className='pb-4 w-full flex flex-row justify-between items-center'>
-            <div className='font-SCDream7 text-[1.5625rem]'>
-              {data.name}님의 자산
-            </div>
-            <MicroMiniBtn
-              text={hideAmount ? '금액 보기' : '금액 숨김'}
-              onClick={() => setHideAmount((prev) => !prev)}
-            />
-          </div>
-          <div className='w-full font-SCDream3 text-[1.25rem]'>
-            나의 총 자산
-          </div>
-          <div className='w-full flex flex-row justify-between items-center'>
-            {hideAmount ? (
-              <div className='font-SCDream8 text-3xl text-gray-400'>
-                금액 숨김
-              </div>
-            ) : (
-              <div className='font-SCDream8 text-3xl'>
-                {mydata.totalAsset.toLocaleString()}원
-              </div>
-            )}
+    <div className='p-6 space-y-8 mt-50 mb-28'>
+      <div className='fixed top-0 left-0 pt-6 px-6 w-full bg-background z-50'>
+        <NavHeader location={'하나 지갑 관리하기'} beforePageUrl={'/home'} />
+      </div>
 
-            <GraphToggle initialState={'bar'} onToggle={setGraphType} />
-          </div>
-          <div>
-            {graphType == 'bar' ? (
-              <BarGraph
-                type={'statistics'}
-                depositPercentage={mydata.depositPercentage}
-                savingsPercentage={mydata.savingsPercentage}
-                loanPercentage={mydata.loanPercentage}
-                stockPercentage={mydata.stockPercentage}
-                realEstatePercentage={mydata.realEstatePercentage}
+      <div style={{ marginTop: '4rem' }}>
+        <Section>
+          <div className='w-full space-y-3'>
+            <div className='pb-4 w-full flex flex-row justify-between items-center'>
+              <div className='font-SCDream7 text-[1.5625rem]'>
+                {data.name}님의 자산
+              </div>
+              <MicroMiniBtn
+                text={hideAmount ? '금액 보기' : '금액 숨김'}
+                onClick={() => setHideAmount((prev) => !prev)}
               />
-            ) : (
-              <CircleGraph
-                type={'statistics'}
-                depositPercentage={mydata.depositPercentage}
-                savingsPercentage={mydata.savingsPercentage}
-                loanPercentage={mydata.loanPercentage}
-                stockPercentage={mydata.stockPercentage}
-                realEstatePercentage={mydata.realEstatePercentage}
-              />
-            )}
-          </div>
-          <div className='flex flex-row justify-between w-full font-SCDream3 text-[1.0625rem]'>
-            <div>월평균 고정지출</div>
+            </div>
+            <div className='w-full font-SCDream3 text-[1.25rem]'>
+              나의 총 자산
+            </div>
+            <div className='w-full flex flex-row justify-between items-center'>
+              {hideAmount ? (
+                <div className='font-SCDream8 text-3xl text-gray-400'>
+                  금액 숨김
+                </div>
+              ) : (
+                <div className='font-SCDream8 text-3xl'>
+                  {mydata.totalAsset.toLocaleString()}원
+                </div>
+              )}
+
+              <GraphToggle initialState={'bar'} onToggle={setGraphType} />
+            </div>
             <div>
-              <span className='font-SCDream5 text-[1.0625rem]'>
-                {averageExpense.toLocaleString()}
-              </span>
-              원
+              {graphType == 'bar' ? (
+                <BarGraph
+                  type={'statistics'}
+                  depositPercentage={mydata.depositPercentage}
+                  savingsPercentage={mydata.savingsPercentage}
+                  loanPercentage={mydata.loanPercentage}
+                  stockPercentage={mydata.stockPercentage}
+                  realEstatePercentage={mydata.realEstatePercentage}
+                />
+              ) : (
+                <CircleGraph
+                  type={'statistics'}
+                  depositPercentage={mydata.depositPercentage}
+                  savingsPercentage={mydata.savingsPercentage}
+                  loanPercentage={mydata.loanPercentage}
+                  stockPercentage={mydata.stockPercentage}
+                  realEstatePercentage={mydata.realEstatePercentage}
+                />
+              )}
+            </div>
+            <div className='flex flex-row justify-between w-full font-SCDream3 text-[1.0625rem]'>
+              <div>월평균 고정지출</div>
+              <div>
+                <span className='font-SCDream5 text-[1.0625rem]'>
+                  {averageExpense.toLocaleString()}
+                </span>
+                원
+              </div>
+            </div>
+            <div className='flex flex-row justify-between w-full font-SCDream3 text-[1.0625rem]'>
+              <div>나의 국민연금 수령 연도</div>
+              <div>
+                <span className='font-SCDream5 text-[1.0625rem]'>
+                  {mydata.pensionStart}
+                </span>
+                년
+              </div>
             </div>
           </div>
-          <div className='flex flex-row justify-between w-full font-SCDream3 text-[1.0625rem]'>
-            <div>나의 국민연금 수령 연도</div>
-            <div>
-              <span className='font-SCDream5 text-[1.0625rem]'>
-                {mydata.pensionStart}
-              </span>
-              년
-            </div>
-          </div>
-        </div>
-      </Section>
+        </Section>
+      </div>
 
       <Section bgColor='hanalightpurple' height='10rem'>
         <div className='w-full flex justify-between'>

--- a/life_on_hana/components/atoms/Btn.tsx
+++ b/life_on_hana/components/atoms/Btn.tsx
@@ -22,7 +22,7 @@ const getBtnClasses = (variant: string) => {
   }
 };
 
-export default function Btn({
+export default function BasicBtn({
   type,
   text,
   url,

--- a/life_on_hana/components/molecules/HistoryItem.tsx
+++ b/life_on_hana/components/molecules/HistoryItem.tsx
@@ -54,7 +54,7 @@ const getLabel = (category: THistoryItemCategoryProps): string => {
     case 'HEALTH':
       return '의료∙건강∙피트니스';
     case 'FIXED_EXPENSE':
-      return '교통∙자동차/주거∙통신/보험∙세금∙기타금융';
+      return '교통/주거∙통신/보험∙기타금융';
     case 'TRAVEL':
       return '여행∙숙박';
     case 'DEPOSIT':


### PR DESCRIPTION
## #️⃣ 이슈 번호

> Resolve: #186

## 💻 작업 내용

- [x] NavHeader 페이지 상단에 고정되도록 수정
<img width="323" alt="image" src="https://github.com/user-attachments/assets/e08bc18c-9895-4f62-99f8-d938610c9cd8" />

- [x] 칼럼 상세보기 페이지에서 칼럼 로고 클릭 시 "/column"으로 이동하도록 로직 추가
- [x] "home/wallet/deposit" 페이지 내 입금 계좌 잔액 폰트 사이즈 up (아래 출금 계좌 잔액 부분과 폰트 사이즈 통일)
- [x] HistoryItem 내 "FIXED_EXPENSE" 라벨 수정 (너무 길어서 UI 망가짐 방지 위함)


## 💬 리뷰 요구사항(선택)
