### PR TITLE
[fix] 🐿️ WhilickItem에서 공유버튼 클릭 시 CopyClipboardBtn이 전달하는 url 수정

### DIFF
--- a/life_on_hana/components/atoms/CopyClipboardBtn.tsx
+++ b/life_on_hana/components/atoms/CopyClipboardBtn.tsx
@@ -3,15 +3,23 @@ import Image from 'next/image';
 import CopyClipboardBtnImg from '@/assets/CopyClipboardBtnImg.svg';
 import { useToast } from '@/hooks/use-toast';
 
-export default function CopyClipboardBtn() {
+export default function CopyClipboardBtn({
+  articleId,
+}: {
+  articleId?: number;
+}) {
   const [currentUrl, setCurrentUrl] = useState('');
   const { toast } = useToast();
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      setCurrentUrl(window.location.href);
+      setCurrentUrl(
+        articleId
+          ? `${window.location.origin}/column/${articleId}`
+          : window.location.href
+      );
     }
-  }, []);
+  }, [articleId]);
 
   const handleCopy = () => {
     if (currentUrl) {

--- a/life_on_hana/components/molecules/WhilickItem.tsx
+++ b/life_on_hana/components/molecules/WhilickItem.tsx
@@ -292,7 +292,7 @@ export default function WhilickItem({
 
         {/* 클립보드복사, 좋아요 */}
         <div className='absolute right-10 bottom-48 z-50 flex items-center gap-4'>
-          <CopyClipboardBtn />
+          <CopyClipboardBtn articleId={articleId} />
           <IsLike
             likeCount={likeCountNum}
             isLiked={isLikedNum}


### PR DESCRIPTION
props로 받은 articleId가 있을 경우 `${window.location.origin}/column/${articleId}`

## #️⃣ 이슈 번호

> Resolve: #190

## 💻 작업 내용

CopyClipboardBtn 컴포넌트에 articleId을 props 로 전달해주어
articleId 유무에 따라 공유하는 url이 바뀌도록 함

## 💬 리뷰 요구사항(선택)
